### PR TITLE
Update crate version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-tools"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "Some internal rustc tools made accessible"


### PR DESCRIPTION
Follow-up of https://github.com/GuillaumeGomez/rustc-tools/pull/15.