### PR TITLE
examples/lint: Remove unused `Result::map`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "term",
 ]

--- a/examples/lint.rs
+++ b/examples/lint.rs
@@ -108,6 +108,5 @@ fn main() -> Result<(), ()> {
         store.register_early_pass(|| Box::new(WarnGenerics));
         store.register_late_pass(|_| Box::new(OddFunctionLineCount));
     })
-    .map(|_| ())
     .map_err(|_| ())
 }


### PR DESCRIPTION
`with_lints` already returns a `Result<(), _>`, so mapping the `Ok` value
to `()` does nothing.
