### PR TITLE
Update compiler version to 2024-07-19 (rust 1.81.0-nightly)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-tools"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cargo_metadata",
  "term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-tools"
-version = "0.80.0"
+version = "0.81.0"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "Some internal rustc tools made accessible"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Some internal rustc tools made accessible (by wrapping the setup part away).
 
 API documentation is available [here](https://guillaumegomez.github.io/rustc-tools/index.html).
 
-The versioning is following the official Rust version it's matching. So version `0.78` means it's on par with Rust `1.78`.
+The versioning is following the official Rust version it's matching. So version `0.x` means it's on par with Rust `1.x`.
 
 ## Why would I need this crate?
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-07-25"
+channel = "nightly-2024-07-19"
 components = ["rustc-dev", "rustfmt", "llvm-tools-preview"]


### PR DESCRIPTION
Hey there, really awesome tool, thank you for making it!

Just wanted to update this to Rust `1.81.0` (current stable) which my project is currently using.

According to https://releases.rs/docs/1.81.0, `1.81.0-nightly` corresponds to `nightly-2024-07-19`. See the following output from cargo:

```
info: syncing channel updates for 'nightly-2024-07-19-aarch64-apple-darwin'
info: latest update on 2024-07-19, rust version 1.81.0-nightly (5affbb171 2024-07-18)
```

Since the channel has been `nightly-2024-07-25` (newer) before, I think it's been wrong by accident. The page on https://releases.rs/docs/1.80.0 says "Released on: 25 July, 2024", but I think the date from "Branched from master on: 7 June, 2024" should be taken for the nightly string instead.