### PR TITLE
Update compiler version to 2024-10-11 (rust 1.83)

### DIFF
--- a/examples/with-cargo-integration/README.md
+++ b/examples/with-cargo-integration/README.md
@@ -24,7 +24,7 @@ cargo install --path .
 And then we install `cargo-tools` with:
 
 ```
-cargo install --path ../..
+cargo install --path ../cargo-tools
 ```
 
 And now you can run `cargo tools` on any crate you want!

--- a/examples/with-cargo-integration/cargo-tools-inner/rust-toolchain
+++ b/examples/with-cargo-integration/cargo-tools-inner/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-07-25"
+channel = "nightly-2024-10-11"
 components = ["rustc-dev", "rustfmt", "llvm-tools-preview"]

--- a/examples/with-cargo-integration/cargo-tools-inner/src/unwrap_call.rs
+++ b/examples/with-cargo-integration/cargo-tools-inner/src/unwrap_call.rs
@@ -14,27 +14,24 @@ declare_lint_pass!(UnwrapCall => [UNWRAP_CALL]);
 
 impl<'tcx> LateLintPass<'tcx> for UnwrapCall {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
-        match expr.kind {
-            ExprKind::MethodCall(name, recv, _args, span) => {
-                if name.ident.as_str() != "unwrap" {
-                    return;
-                }
-                let caller_ty = cx.typeck_results().expr_ty(recv);
-                let is_option_or_result = match caller_ty.kind() {
-                    ty::Adt(adt, _) => {
-                        cx.tcx.is_diagnostic_item(sym::Option, adt.did())
-                            || cx.tcx.is_diagnostic_item(sym::Result, adt.did())
-                    }
-                    _ => false,
-                };
-                if !is_option_or_result {
-                    return;
-                }
-                cx.span_lint(UNWRAP_CALL, span, |diag| {
-                    diag.primary_message("avoid using `unwrap` if possible");
-                });
+        if let ExprKind::MethodCall(name, recv, _args, span) = expr.kind {
+            if name.ident.as_str() != "unwrap" {
+                return;
             }
-            _ => {}
+            let caller_ty = cx.typeck_results().expr_ty(recv);
+            let is_option_or_result = match caller_ty.kind() {
+                ty::Adt(adt, _) => {
+                    cx.tcx.is_diagnostic_item(sym::Option, adt.did())
+                        || cx.tcx.is_diagnostic_item(sym::Result, adt.did())
+                }
+                _ => false,
+            };
+            if !is_option_or_result {
+                return;
+            }
+            cx.span_lint(UNWRAP_CALL, span, |diag| {
+                diag.primary_message("avoid using `unwrap` if possible");
+            });
         }
     }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-07-25"
+channel = "nightly-2024-10-11"
 components = ["rustc-dev", "rustfmt", "llvm-tools-preview"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -51,7 +51,7 @@ impl SilentOnIgnoredFilesEmitter {
 }
 
 impl Translate for SilentOnIgnoredFilesEmitter {
-    fn fluent_bundle(&self) -> Option<&Lrc<rustc_errors::FluentBundle>> {
+    fn fluent_bundle(&self) -> Option<&rustc_errors::FluentBundle> {
         self.emitter.fluent_bundle()
     }
 
@@ -61,7 +61,7 @@ impl Translate for SilentOnIgnoredFilesEmitter {
 }
 
 impl Emitter for SilentOnIgnoredFilesEmitter {
-    fn source_map(&self) -> Option<&Lrc<SourceMap>> {
+    fn source_map(&self) -> Option<&SourceMap> {
         None
     }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,6 +13,8 @@ use rustc_session::parse::ParseSess;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::{FilePathMapping, SourceMap};
 
+/// Parse the AST of the crate pointed by "path" and run a callback on each node.
+///
 /// You can check `ParseSess` documentation [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_session/parse/struct.ParseSess.html)
 /// and `Crate` documentation [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/struct.Crate.html).
 ///

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -62,6 +62,8 @@ pub fn cargo_integration<T, F: Fn(&[String]) -> T>(
         }
     }
 
+    command.wait().unwrap();
+
     let artifact = match artifacts.pop() {
         Some(artifact) => artifact,
         None => return Err("Nothing to check?".to_string()),


### PR DESCRIPTION
Update the compiler to the latest version (1.83): https://releases.rs/docs/1.83.0/. Hopefully this time I didn't make the same mistake as last time and picked the right nightly (2024-10-11).

The CI with the example repo won't pass because of a chicken and egg problem.
How do you want to handle it ? I can make a PR on the other repo too but we need to merge it before this one.